### PR TITLE
imp(src): add graph widgets to dashboard page

### DIFF
--- a/src/backend/api.py
+++ b/src/backend/api.py
@@ -379,6 +379,8 @@ class GeneratedGraphs(BaseModel):
     graphType: str
     data: List[Dict]
     properties: List[Dict]
+    attributes: List[str]
+
 @app.put("/generatedGraphs")
 async def addGeneratedGraphs(payload: GeneratedGraphs):
     """
@@ -392,7 +394,8 @@ async def addGeneratedGraphs(payload: GeneratedGraphs):
         "_id": nextId,  
         "graphtype": payload.graphType,
         "data": payload.data,
-        "properties": payload.properties
+        "properties": payload.properties,
+        "attributes": payload.attributes
     }
 
     try:

--- a/src/frontend/src/components/sidebars/GraphSideBar.tsx
+++ b/src/frontend/src/components/sidebars/GraphSideBar.tsx
@@ -11,31 +11,18 @@ import {
 import Button from "@mui/material/Button";
 import GenerateGraphModal from "../modal/DataFormModal";
 import { FormDataContext } from "../../pages/DataVisualize";
-import { useQuery, gql } from "@apollo/client";
+import useGraphs from "../../hooks/useGraphs";
 
 type GraphSideBarProps = {
   onSubmit: () => void;
   onGraphSelect: (graphData: any) => void;
 };
 
-const GET_GRAPH = gql`
-  query GetLastestGraph($latest: Int) {
-    getLastestGraph(latest: $latest)
-  }
-`;
-
 const GraphSideBar: React.FC<GraphSideBarProps> = ({ onSubmit, onGraphSelect }) => {
   const [selectedGraphId, setSelectedGraphId] = useState<number | null>(null);
 
-  const { data: generatedGraphData } = useQuery<{ getLastestGraph: any[] }>(
-    GET_GRAPH,
-    {
-      variables: { latest: 0 },
-    }
-  );
-
-  const result = generatedGraphData?.getLastestGraph ?? [];
-  console.log(result);
+  const { latestGraphs, loading, error } = useGraphs(0);
+  const validGraphs = latestGraphs?.filter((graph) => graph !== null && graph !== undefined) ?? [];
 
   const [isOpen, setIsOpen] = useState<boolean>(true);
   const [modalOpen, setModalOpen] = useState(false);
@@ -101,7 +88,7 @@ const GraphSideBar: React.FC<GraphSideBarProps> = ({ onSubmit, onGraphSelect }) 
 
   const handleSelectGraph = (id: number) => {
     setSelectedGraphId(id);
-    const selectedGraph = result.find((graph) => graph._id === id);
+    const selectedGraph = latestGraphs.find((graph) => graph._id === id);
     if (selectedGraph) {
       handleGraphData(selectedGraph);
     }
@@ -162,7 +149,11 @@ const GraphSideBar: React.FC<GraphSideBarProps> = ({ onSubmit, onGraphSelect }) 
             </li>
           </div>
           <div className={`relative items-center ${isOpen ? "-ml-0" : "-ml-3"}`}>
-          {result.map((r) => (
+            {loading ? (
+              <li className="flex ml-2 font-semibold text-sm">LOADING...</li>
+            ) : error ? (
+              <li className="flex ml-2 font-semibold text-sm">Error fetching graphs</li>
+            ) : validGraphs.map((r) => (
             <li
               key={r._id}
               className={`flex rounded-md hover:bg-light-white text-sm items-center gap-x-4 mb-2 

--- a/src/frontend/src/graphql/graphs.ts
+++ b/src/frontend/src/graphql/graphs.ts
@@ -16,7 +16,7 @@ export const typeDefs = gql`
     }
     
     type Mutation {
-      addGeneratedGraphs(graphType: String!, data:[JSON]!, properties:[JSON]!): String!
+      addGeneratedGraphs(graphType: String!, data:[JSON]!, properties:[JSON]!, attributes: [String!]!): String!
    }
 `;
 
@@ -101,9 +101,9 @@ export const resolvers = {
   Mutation: {
     addGeneratedGraphs: async(
         _:undefined,
-        {graphType, data, properties}:{graphType: string, data:[], properties:[]}):Promise<string> => {
+        {graphType, data, properties, attributes}:{graphType: string, data:[], properties:[], attributes: string[]}):Promise<string> => {
             try {
-            const response = await axios.put("http://127.0.0.1:8000/generatedGraphs", {graphType, data, properties}, {
+            const response = await axios.put("http://127.0.0.1:8000/generatedGraphs", {graphType, data, properties, attributes}, {
               headers: { "Content-Type": "application/json" },
             });
 

--- a/src/frontend/src/hooks/useGraphs.tsx
+++ b/src/frontend/src/hooks/useGraphs.tsx
@@ -1,0 +1,22 @@
+import { gql, useQuery } from "@apollo/client";
+
+const GET_GRAPH = gql`
+  query GetLastestGraph($latest: Int) {
+    getLastestGraph(latest: $latest)
+  }
+`;
+
+const useGraphs = (latestNum: number) => {
+  const { data: generatedGraphData, loading, error } = useQuery<{ getLastestGraph: any[] }>(
+    GET_GRAPH,
+    {
+      variables: { latest: latestNum },
+    }
+  );
+
+  const latestGraphs = generatedGraphData?.getLastestGraph ?? [];
+
+  return { latestGraphs, loading, error }
+};
+
+export default useGraphs;

--- a/src/frontend/src/pages/DataVisualize.tsx
+++ b/src/frontend/src/pages/DataVisualize.tsx
@@ -106,11 +106,13 @@ const SAVE_GRAPH = gql`
     $graphType: String!
     $data: [JSON]!
     $properties: [JSON]!
+    $attributes: [String!]!
   ) {
     addGeneratedGraphs(
       graphType: $graphType
       data: $data
       properties: $properties
+      attributes: $attributes
     )
   }
 `;
@@ -248,6 +250,7 @@ const DataVisualize: React.FC = () => {
           graphType: selectedGraphType,
           data: data?.getFilterCollectionData?.data ?? [],
           properties: [graphProperties], 
+          attributes: [selectedParamX, selectedParamY]
         },
       });
     } catch (error) {
@@ -260,13 +263,13 @@ const DataVisualize: React.FC = () => {
   };
 
   const handleGraphSelect = (graphData: any) => {
-    setSelectedGraphData(graphData);
     const transformedData = graphData.data ? transformDataForScatter(graphData.data) : [];
+    setSelectedGraphData(transformedData)
     setSubmit(true);
   };
 
   React.useEffect(() => {
-    if (!loading && submit) {
+    if (!loading && !selectedGraphData && submit) {
       saveGraph();
     }
   }, [loading, submit, data?.getFilterCollectionData?.data]);
@@ -325,13 +328,11 @@ const DataVisualize: React.FC = () => {
                         height={dimensions.height}
                         lineData={lineData}
                       />
-                      <div className="relative mt-2 p-2">
+                      {R_squared ? (<div className="relative mt-2 p-2">
                         <h6>
-                          R<sup>2</sup> (coefficient of determination):{" "}
-                          {R_squared ? R_squared.toFixed(2) : "Loading..."}
+                          R<sup>2</sup> (coefficient of determination): {""}{R_squared.toFixed(2)}
                         </h6>
-                        {R_squared ? (
-                          R_squared < 0.5 ? (
+                        {R_squared < 0.5 ? (
                             <p>
                               The linear model explains less than 50% of the
                               variability in the data, suggesting a poor fit.
@@ -343,10 +344,8 @@ const DataVisualize: React.FC = () => {
                               strong fit.
                             </p>
                           )
-                        ) : (
-                          <p>Loading...</p>
-                        )}
-                      </div>
+                        }
+                      </div>) : ""}
                     </>
                   ) : null}
                 </div>


### PR DESCRIPTION
includes:
- updated dashboard page with graph widgets
- useGraphs hook to fetch `n` latest graphs
- saving attributes when saving a graph
- prevent re-saving a graph when loading one from the sidebar